### PR TITLE
Updated path for aline_data.csv

### DIFF
--- a/notebooks/aline-aws/aline_propensity_score.ipynb
+++ b/notebooks/aline-aws/aline_propensity_score.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wdpath = paste(path.expand(\"~\"),'SageMaker/mimic-code/notebooks/alineaws',sep='/')\n",
+    "wdpath = path.expand(\"./\")\n",
     "setwd(wdpath)\n",
     "dataset = read.csv(file=\"aline_data.csv\",head=TRUE,sep=\",\")"
    ]
@@ -951,7 +951,7 @@
    "mimetype": "text/x-r-source",
    "name": "R",
    "pygments_lexer": "r",
-   "version": "3.6.0"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changes to the directory structure of the AWS aline files necessitated a pathing change. Now the aline_data.csv file path is relative instead of absolute.